### PR TITLE
Changed DistanceMatrixRequest to accept an ILocationString instead of…

### DIFF
--- a/GoogleApi.Test/Maps/MapsTest.cs
+++ b/GoogleApi.Test/Maps/MapsTest.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using GoogleApi.Entities.Common;
 using GoogleApi.Entities.Maps.Directions.Request;
+using GoogleApi.Entities.Maps.DistanceMatrix.Request;
 using GoogleApi.Entities.Maps.Elevation.Request;
 using GoogleApi.Entities.Maps.Geocode.Request;
 using NUnit.Framework;
@@ -164,7 +165,21 @@ namespace GoogleApi.Test.Maps
         [Test]
         public void DistanceMatrixTest()
         {
-            Assert.Inconclusive();
+            var request = new DistanceMatrixRequest { Origins = new [] {new Location(40.7141289, -73.9614074), }, Destinations = new [] { new AddressLocation("185 Broadway Ave, Manhattan, NY, USA") }};
+
+            var _result = GoogleMaps.DistanceMatrix.Query(request);
+
+            Assert.AreEqual(8247, _result.Rows.First().Elements.First().Distance.Value);
+        }
+
+        [Test]
+        public void DistanceMatrixAsyncTest()
+        {
+            var request = new DistanceMatrixRequest { Origins = new[] { new Location(40.7141289, -73.9614074), }, Destinations = new[] { new AddressLocation("185 Broadway Ave, Manhattan, NY, USA") } };
+
+            var _result = GoogleMaps.DistanceMatrix.QueryAsync(request).GetAwaiter().GetResult();
+
+            Assert.AreEqual(8247, _result.Rows.First().Elements.First().Distance.Value);
         }
 
         [Test]

--- a/GoogleApi/Entities/Common/AddressLocation.cs
+++ b/GoogleApi/Entities/Common/AddressLocation.cs
@@ -1,6 +1,6 @@
-using GoogleApi.Entities.Maps.Common.Interfaces;
+using GoogleApi.Entities.Common.Interfaces;
 
-namespace GoogleApi.Entities.Maps.Common
+namespace GoogleApi.Entities.Common
 {
     /// <summary>
     /// 
@@ -28,5 +28,10 @@ namespace GoogleApi.Entities.Maps.Common
 		{
 			get { return this.Address; }
 		}
+
+        public override string ToString()
+        {
+            return LocationString;
+        }
 	}
 }

--- a/GoogleApi/Entities/Common/Interfaces/ILocationString.cs
+++ b/GoogleApi/Entities/Common/Interfaces/ILocationString.cs
@@ -1,4 +1,4 @@
-namespace GoogleApi.Entities.Maps.Common.Interfaces
+namespace GoogleApi.Entities.Common.Interfaces
 {
     /// <summary>
     /// Interface for converting addresses and coordinates into google compatible location strings.

--- a/GoogleApi/Entities/Common/Location.cs
+++ b/GoogleApi/Entities/Common/Location.cs
@@ -1,6 +1,6 @@
 ﻿using System.Globalization;
 using System.Runtime.Serialization;
-using GoogleApi.Entities.Maps.Common.Interfaces;
+using GoogleApi.Entities.Common.Interfaces;
 
 namespace GoogleApi.Entities.Common
 {

--- a/GoogleApi/Entities/Maps/DistanceMatrix/Request/DistanceMatrixRequest.cs
+++ b/GoogleApi/Entities/Maps/DistanceMatrix/Request/DistanceMatrixRequest.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
-using GoogleApi.Entities.Common;
+using GoogleApi.Entities.Common.Interfaces;
 using GoogleApi.Entities.Maps.Common;
 using GoogleApi.Entities.Maps.Common.Enums;
 using GoogleApi.Helpers;
@@ -17,13 +17,13 @@ namespace GoogleApi.Entities.Maps.DistanceMatrix.Request
         /// One or more addresses and/or textual latitude/longitude values, separated with the pipe (|) character, from which to calculate distance and time. If you pass an address as a string, 
         /// the service will geocode the string and convert it to a latitude/longitude coordinate to calculate directions. If you pass coordinates, ensure that no space exists between the latitude and longitude values.
 		/// </summary>
-        public virtual IEnumerable<Location> Origins { get; set; }
+        public virtual IEnumerable<ILocationString> Origins { get; set; }
 
         /// <summary>
         /// One or more addresses and/or textual latitude/longitude values, separated with the pipe (|) character, to which to calculate distance and time. 
         /// If you pass an address as a string, the service will geocode the string and convert it to a latitude/longitude coordinate to calculate directions. If you pass coordinates, ensure that no space exists between the latitude and longitude values
 		/// </summary>
-        public virtual IEnumerable<Location> Destinations { get; set; }
+        public virtual IEnumerable<ILocationString> Destinations { get; set; }
         
         /// <summary>
         /// Distance Matrix results contain text within distance fields to indicate the distance of the calculated route. The unit system to use can be specified:

--- a/GoogleApi/GoogleApi.csproj
+++ b/GoogleApi/GoogleApi.csproj
@@ -52,14 +52,10 @@
     <Compile Include="Engine\GenericEngine.cs">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="Entities\Common\AddressLocation.cs" />
+    <Compile Include="Entities\Common\Interfaces\ILocationString.cs" />
     <Compile Include="Entities\Common\SignableRequest.cs" />
-    <Compile Include="Entities\Maps\Common\AddressLocation.cs">
-      <SubType>Code</SubType>
-    </Compile>
     <Compile Include="Entities\Common\BaseRequest.cs" />
-    <Compile Include="Entities\Maps\Common\Interfaces\ILocationString.cs">
-      <SubType>Code</SubType>
-    </Compile>
     <Compile Include="Entities\Common\Interfaces\IResponseFor.cs">
       <SubType>Code</SubType>
     </Compile>


### PR DESCRIPTION
… concrete Location class

Re issue #2.

I originally planned to change the `Location` class to have an `Address` string property but because this class is used in many other places I thought it'd be better to use the `ILocationString` interface. I did think about having an abstract Location base class with GeoLocation and AddressLocation inheriting from it but this would have been a breaking change. Can change some things around to make this happen if you prefer :)

Thanks