### PR TITLE
added a link to RapidAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,26 @@ Google Places
 Google Translate 
   * Translate
 
+<div style="margin: 25px;">
+<a href="https://rapidapi.com/package/GoogleTranslate/functions?utm_source=GoogleTranslateGitHub-Node&utm_medium=button&utm_content=Vendor_GitHub" style="
+    all: initial;
+    background-color: #498FE1;
+    border-width: 0;
+    border-radius: 5px;
+    padding: 10px 20px;
+    color: white;
+    font-family: 'Helvetica';
+    font-size: 12pt;
+    background-image: url(https://scdn.rapidapi.com/logo-small.png);
+    background-size: 25px;
+    background-repeat: no-repeat;
+    background-position-y: center;
+    background-position-x: 10px;
+    padding-left: 44px;
+    cursor: pointer;">
+  Run now on <b>RapidAPI</b>
+</a>
+</div>
 
 
 Google Functions 


### PR DESCRIPTION
I've added a link for the Google Translate API that links directly to it's RapidAPI package. This will provide an easy way for devs to test out the API before implementation