### PR TITLE
Fallback on `unknown` when place location type deserialization fails

### DIFF
--- a/GoogleApi/Entities/Places/Add/Request/PlacesAddRequest.cs
+++ b/GoogleApi/Entities/Places/Add/Request/PlacesAddRequest.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using GoogleApi.Entities.Common;
+using GoogleApi.Entities.Common.Converters;
 using GoogleApi.Entities.Common.Enums;
 using GoogleApi.Entities.Interfaces;
 using Newtonsoft.Json;
@@ -76,7 +77,7 @@ namespace GoogleApi.Entities.Places.Add.Request
         /// XML requests require a single type element. See the list of supported types for more information.  
         /// If none of the supported types are a match for this place, you may specify other.
         /// </summary>
-        [JsonProperty("types", ItemConverterType = typeof(StringEnumConverter))]
+        [JsonProperty("types", ItemConverterType = typeof(StringEnumOrDefaultConverter<PlaceLocationType>))]
         public virtual IEnumerable<PlaceLocationType> Types { get; set; }
 
         /// <summary>

--- a/GoogleApi/Entities/Places/Common/Prediction.cs
+++ b/GoogleApi/Entities/Places/Common/Prediction.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using GoogleApi.Entities.Common.Converters;
 using GoogleApi.Entities.Common.Enums;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
@@ -41,7 +42,7 @@ namespace GoogleApi.Entities.Places.Common
         /// <summary>
         /// Types is an array indicating the type of the prediction.
         /// </summary>        
-        [JsonProperty("types", ItemConverterType = typeof(StringEnumConverter))]
+        [JsonProperty("types", ItemConverterType = typeof(StringEnumOrDefaultConverter<PlaceLocationType>))]
         public virtual IEnumerable<PlaceLocationType> Types { get; set; }
 
         /// <summary>

--- a/GoogleApi/Entities/Places/Details/Response/DetailsResult.cs
+++ b/GoogleApi/Entities/Places/Details/Response/DetailsResult.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using GoogleApi.Entities.Common;
+using GoogleApi.Entities.Common.Converters;
 using GoogleApi.Entities.Common.Enums;
 using GoogleApi.Entities.Places.Common;
 using GoogleApi.Entities.Places.Common.Enums;
@@ -143,7 +144,7 @@ namespace GoogleApi.Entities.Places.Details.Response
         /// Types contains an array of feature types describing the given result. See the list of supported types for more information. 
         /// XML responses include multiple type elements if more than one type is assigned to the result.
         /// </summary>
-        [JsonProperty("types", ItemConverterType = typeof(StringEnumConverter))]
+        [JsonProperty("types", ItemConverterType = typeof(StringEnumOrDefaultConverter<PlaceLocationType>))]
         public virtual IEnumerable<PlaceLocationType> Types { get; set; }
 
         /// <summary>


### PR DESCRIPTION
see https://github.com/vivet/GoogleApi/issues/69
and https://github.com/vivet/GoogleApi/issues/50