### PR TITLE
Fixed invalid EnumMember.Value in ElectronicsStore value.

### DIFF
--- a/GoogleApi/Entities/Places/Search/Common/Enums/SearchPlaceType.cs
+++ b/GoogleApi/Entities/Places/Search/Common/Enums/SearchPlaceType.cs
@@ -203,7 +203,7 @@ namespace GoogleApi.Entities.Places.Search.Common.Enums
         /// <summary>
         /// Electronics Store.
         /// </summary>
-        [EnumMember(Value = "department_store")]
+        [EnumMember(Value = "electronics_store")]
         ElectronicsStore,
 
         /// <summary>


### PR DESCRIPTION
ElectronicsStore in SearchPlaceType has invalid Value in EnumMember attribute.