### PR TITLE
Fix bounds order when geocoding an address

### DIFF
--- a/.tests/GoogleApi.Test/Maps/Geocoding/Address/AddressGeocodeTests.cs
+++ b/.tests/GoogleApi.Test/Maps/Geocoding/Address/AddressGeocodeTests.cs
@@ -97,6 +97,30 @@ namespace GoogleApi.Test.Maps.Geocoding.Address
         }
 
         [Test]
+        public void AddressGeocodeWhenBoundsAmbiguousTest()
+        {
+            var request = new AddressGeocodeRequest
+            {
+                Key = this.ApiKey,
+                Address = "Yellow Rock",
+                Bounds = new ViewPort
+                {
+                    NorthEast = new Entities.Common.Location(37.771819, -111.603914),
+                    SouthWest = new Entities.Common.Location(37.039739, -112.514545)
+                }
+            };
+            var result = GoogleMaps.AddressGeocode.QueryAsync(request).Result;
+
+            Assert.IsNotNull(result);
+            Assert.AreEqual(Status.Ok, result.Status);
+
+            var geocodeResult = result.Results.FirstOrDefault();
+            Assert.IsNotNull(geocodeResult);
+            Assert.AreEqual(37.2583855, geocodeResult.Geometry.Location.Latitude, 0.001);
+            Assert.AreEqual(-111.9221377, geocodeResult.Geometry.Location.Longitude, 0.001);
+        }
+
+        [Test]
         public void AddressGeocodeWhenRegionTest()
         {
             var request = new AddressGeocodeRequest

--- a/GoogleApi/Entities/Maps/Geocoding/Address/Request/AddressGeocodeRequest.cs
+++ b/GoogleApi/Entities/Maps/Geocoding/Address/Request/AddressGeocodeRequest.cs
@@ -55,7 +55,7 @@ namespace GoogleApi.Entities.Maps.Geocoding.Address.Request
                 parameters.Add("region", this.Region);
 
             if (this.Bounds != null)
-                parameters.Add("bounds", $"{this.Bounds.NorthEast}|{this.Bounds.SouthWest}");
+                parameters.Add("bounds", $"{this.Bounds.SouthWest}|{this.Bounds.NorthEast}");
 
             if (this.Components != null && this.Components.Any())
                 parameters.Add("components", string.Join("|", this.Components.Select(x => $"{x.Key.ToString().ToLower()}:{x.Value}")));


### PR DESCRIPTION
Turns out the correct order is sw|ne...