### PR TITLE
Target more recent .NET Standard platforms

### DIFF
--- a/GoogleApi/GoogleApi.csproj
+++ b/GoogleApi/GoogleApi.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <TargetFramework></TargetFramework>
-    <TargetFrameworks>netstandard1.1;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard1.1;netstandard1.4;netstandard2.0;net45</TargetFrameworks>
     <ApplicationIcon>icon.ico</ApplicationIcon>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>


### PR DESCRIPTION
This package should provide at least a 2.0 target. I added the usual list.

cf https://docs.microsoft.com/en-us/dotnet/standard/library-guidance/cross-platform-targeting