### PR TITLE
Support avoiding ferries

### DIFF
--- a/.tests/GoogleApi.Test/Maps/Directions/DirectionsTests.cs
+++ b/.tests/GoogleApi.Test/Maps/Directions/DirectionsTests.cs
@@ -5,6 +5,7 @@ using GoogleApi.Entities.Common;
 using GoogleApi.Entities.Common.Enums;
 using GoogleApi.Entities.Maps.Common.Enums;
 using GoogleApi.Entities.Maps.Directions.Request;
+using GoogleApi.Entities.Maps.Directions.Response.Enums;
 using GoogleApi.Exceptions;
 using NUnit.Framework;
 
@@ -120,6 +121,30 @@ namespace GoogleApi.Test.Maps.Directions
             Assert.IsNotNull(result);
             Assert.AreEqual(Status.Ok, result.Status);
             Assert.IsNotEmpty(result.Routes);
+        }
+
+        [Test]
+        public void DirectionsWhenAvoidFerriesTest()
+        {
+            var request = new DirectionsRequest
+            {
+                Key = this.ApiKey,
+                Origin = new Location("1001 Alaskan Way, Seattle, WA 98104"),
+                Destination = new Location("550 Winslow Way E, Bainbridge Island, WA 98110"),
+                Avoid = AvoidWay.Ferries
+            };
+
+            var result = GoogleMaps.Directions.Query(request);
+
+            Assert.IsNotNull(result);
+            Assert.AreEqual(Status.Ok, result.Status);
+            Assert.IsNotEmpty(result.Routes);
+
+            Assert.IsFalse((from route in result.Routes
+                            from leg in route.Legs
+                            from step in leg.Steps
+                            where step.Maneuver == ManeuverAction.Ferry
+                            select step).Any());
         }
 
         [Test]

--- a/.tests/GoogleApi.UnitTests/Maps/Directions/DirectionsRequestTests.cs
+++ b/.tests/GoogleApi.UnitTests/Maps/Directions/DirectionsRequestTests.cs
@@ -147,7 +147,7 @@ namespace GoogleApi.UnitTests.Maps.Directions
                 Key = "abc",
                 Origin = new Location("285 Bedford Ave, Brooklyn, NY, USA"),
                 Destination = new Location("185 Broadway Ave, Manhattan, NY, USA"),
-                Avoid = AvoidWay.Highways | AvoidWay.Indoor
+                Avoid = AvoidWay.Highways | AvoidWay.Indoor | AvoidWay.Ferries
             };
 
             var uri = request.GetUri();

--- a/GoogleApi/Entities/Maps/Common/Enums/AvoidWay.cs
+++ b/GoogleApi/Entities/Maps/Common/Enums/AvoidWay.cs
@@ -26,6 +26,11 @@ namespace GoogleApi.Entities.Maps.Common.Enums
         /// <summary>
         /// Avoid indoor
         /// </summary>
-        Indoor = 1 << 2
+        Indoor = 1 << 2,
+
+        /// <summary>
+        /// Avoid ferries
+        /// </summary>
+        Ferries = 1 << 3
     }
 }


### PR DESCRIPTION
Ferry avoidance was missing from the enum.

cf https://developers.google.com/maps/documentation/directions/intro?hl=ja#Restrictions