### PR TITLE
Enum to String using invariant culture

### DIFF
--- a/GoogleApi/Entities/Places/Details/Request/PlacesDetailsRequest.cs
+++ b/GoogleApi/Entities/Places/Details/Request/PlacesDetailsRequest.cs
@@ -70,7 +70,7 @@ namespace GoogleApi.Entities.Places.Details.Request
             var fields = Enum.GetValues(typeof(FieldTypes))
                 .Cast<FieldTypes>()
                 .Where(x => this.Fields.HasFlag(x) && x != FieldTypes.Basic && x != FieldTypes.Contact && x != FieldTypes.Atmosphere)
-                .Aggregate(string.Empty, (current, x) => $"{current}{x.ToString().ToLower()},");
+                .Aggregate(string.Empty, (current, x) => $"{current}{x.ToString().ToLowerInvariant()},");
 
             parameters.Add("fields", fields.EndsWith(",") ? fields.Substring(0, fields.Length - 1) : fields);
 

--- a/GoogleApi/Entities/Places/Search/Find/Request/PlacesFindSearchRequest.cs
+++ b/GoogleApi/Entities/Places/Search/Find/Request/PlacesFindSearchRequest.cs
@@ -89,7 +89,7 @@ namespace GoogleApi.Entities.Places.Search.Find.Request
             var fields = Enum.GetValues(typeof(FieldTypes))
                 .Cast<FieldTypes>()
                 .Where(x => this.Fields.HasFlag(x) && x != FieldTypes.Basic && x != FieldTypes.Contact && x != FieldTypes.Atmosphere)
-                .Aggregate(string.Empty, (current, x) => $"{current}{x.ToString().ToLower()},");
+                .Aggregate(string.Empty, (current, x) => $"{current}{x.ToString().ToLowerInvariant()},");
 
             parameters.Add("fields", fields.EndsWith(",") ? fields.Substring(0, fields.Length - 1) : fields);
             parameters.Add("language", this.Language.ToCode());

--- a/GoogleApi/Entities/Search/Video/BaseVideoSearchRequest.cs
+++ b/GoogleApi/Entities/Search/Video/BaseVideoSearchRequest.cs
@@ -119,7 +119,7 @@ namespace GoogleApi.Entities.Search.Video
             var parts = Enum.GetValues(typeof(PartType))
                 .Cast<PartType>()
                 .Where(x => this.Part.HasFlag(x))
-                .Aggregate(string.Empty, (current, x) => $"{current}{x.ToString().ToLower()},");
+                .Aggregate(string.Empty, (current, x) => $"{current}{x.ToString().ToLowerInvariant()},");
 
             parameters.Add("part", parts.EndsWith(",") ? parts.Substring(0, parts.Length - 1) : parts);
 


### PR DESCRIPTION
We have clients from Azerbaijan and they have reported errors in our app. We are requesting place's details through the Google Places API. 
Error message: Error while parsing 'fields' parameter: Unexpected characters
Azerbaijani alphabet (plus Turkish, Kazakh and possibly others) have casing rules that differ from the English ones. Specifically, they have separate dotted (small U+0069 and capital U+0130) and dotless (small U+0131 and capital U+0049) letters I. When lower-casing from dotless capital I (U+0049) we get dotless small ı (U+0131) and not the dotted small i (U+0069).

Tested on our Android (Xamarin.Android) app.

P.S. Thanks for your hard work!