### PR TITLE
Missing Types array on Places Candidate response

### DIFF
--- a/GoogleApi/Entities/Places/Search/Find/Response/Candidate.cs
+++ b/GoogleApi/Entities/Places/Search/Find/Response/Candidate.cs
@@ -100,5 +100,11 @@ namespace GoogleApi.Entities.Places.Search.Find.Response
         /// </summary>
         [JsonProperty("photos")]
         public virtual IEnumerable<Photo> Photos { get; set; }
+
+        /// <summary>
+        /// An array of types for this place
+        /// </summary>
+        [JsonProperty("types")]
+        public IEnumerable<PlaceLocationType> Types { get; set; }
     }
 }


### PR DESCRIPTION
The current Candidate response object is missing the "types" array. I'm adding this field in the PR