### PR TITLE
Non breaking language enum handling

### DIFF
--- a/.tests/GoogleApi.UnitTests/Translate/Languages/LanguagesRequestTests.cs
+++ b/.tests/GoogleApi.UnitTests/Translate/Languages/LanguagesRequestTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using System.Threading.Tasks;
 using GoogleApi.Entities.Translate.Common.Enums;
 using GoogleApi.Entities.Translate.Common.Enums.Extensions;
 using GoogleApi.Entities.Translate.Languages.Request;
@@ -10,6 +11,21 @@ namespace GoogleApi.UnitTests.Translate.Languages;
 [TestFixture]
 public class LanguagesRequestTests
 {
+    [Test]
+    public async Task Should_Get_Language_List()
+    {
+        //var request = new LanguagesRequest
+        //{
+        //    Key = "KEY"
+        //};
+
+        //var api = new GoogleTranslate.LanguagesApi();
+
+        //var response = await api.QueryAsync(request);
+
+        //Assert.AreEqual(response.Status, GoogleApi.Entities.Common.Enums.Status.Ok);
+    }
+
     [Test]
     public void GetQueryStringParametersTest()
     {

--- a/GoogleApi/Entities/Translate/Common/Enums/Converters/LanguageEnumConverter.cs
+++ b/GoogleApi/Entities/Translate/Common/Enums/Converters/LanguageEnumConverter.cs
@@ -1,0 +1,80 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using Newtonsoft.Json.Utilities;
+using System.Reflection;
+using System.Runtime.Serialization;
+using System;
+using System.Globalization;
+using System.Linq;
+using GoogleApi.Entities.Translate.Common.Enums.Extensions;
+
+namespace GoogleApi.Entities.Translate.Common.Enums.Converters
+{
+    /// <summary>
+    /// Custom Language Enum converter to avoid breaking changes when Google adds a new language to the list.
+    /// </summary>
+    public class LanguageEnumConverter : StringEnumConverter
+    {
+        /// <summary>
+        /// Determines whether this instance can convert the specified object type.
+        /// </summary>
+        /// <param name="objectType">Type of the object.</param>
+        /// <returns>
+        /// <c>true</c> if this instance can convert the specified object type; otherwise, <c>false</c>.
+        /// </returns>
+        public override bool CanConvert(Type objectType)
+        {
+            return base.CanConvert(objectType);
+        }
+
+        /// <summary>
+        /// Attempts to convert the object into a Language. If it can't find the object, it returns Language.Unsupported.
+        /// </summary>
+        /// <param name="reader">The <see cref="JsonReader"/> to read from.</param>
+        /// <param name="objectType">Type of the object.</param>
+        /// <param name="existingValue">The existing value of object being read.</param>
+        /// <param name="serializer">The calling serializer.</param>
+        /// <returns>The enum object representing the language or Language.Unsupported.</returns>
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            var enumString = (string)reader.Value;
+            
+            var list = Enum.GetValues(typeof(Language)).Cast<Language>().Select(s => new LanguageDetails
+            {
+                Name = s.ToString(),
+                Language = s,
+                Code = s.GetEnumMemberValue()
+            }).ToList();
+
+            try
+            {
+                return list.Where(w => string.Equals(w.Code, enumString, StringComparison.InvariantCultureIgnoreCase))
+                .Select(s => s.Language)
+                .First();
+            }
+            catch(InvalidOperationException)
+            {
+                //if the list does not contain the language code in question.
+                return Language.Unsupported;
+            }
+        }
+
+        private struct LanguageDetails
+        {
+            public string Name { get; set; }
+            public string Code { get; set; }
+            public Language Language { get; set; }
+        }
+
+        /// <summary>
+        /// Writes the JSON representation of the object.
+        /// </summary>
+        /// <param name="writer">The <see cref="JsonWriter"/> to write to.</param>
+        /// <param name="value">The value.</param>
+        /// <param name="serializer">The calling serializer.</param>
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            base.WriteJson(writer, value, serializer);
+        }
+    }
+}

--- a/GoogleApi/Entities/Translate/Common/Enums/Extensions/EnumExtension.cs
+++ b/GoogleApi/Entities/Translate/Common/Enums/Extensions/EnumExtension.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Serialization;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace GoogleApi.Entities.Translate.Common.Enums.Extensions
+{
+    /// <summary>
+    /// Enum Extensions
+    /// </summary>
+    public static class EnumExtension
+    {
+        /// <summary>
+        /// Gets the value of the [EnumMember(Value = "...")] tags
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public static string GetEnumMemberValue<T>(this T value)
+    where T : Enum
+        {
+            return typeof(T)
+                .GetTypeInfo()
+                .DeclaredMembers
+                .SingleOrDefault(x => x.Name == value.ToString())
+                ?.GetCustomAttribute<EnumMemberAttribute>(false)
+                ?.Value;
+        }
+    }
+}

--- a/GoogleApi/Entities/Translate/Common/Enums/Language.cs
+++ b/GoogleApi/Entities/Translate/Common/Enums/Language.cs
@@ -830,5 +830,11 @@ public enum Language
     /// Mizo.
     /// </summary>
     [EnumMember(Value = "lus")]
-    Mizo
+    Mizo,
+
+    /// <summary>
+    /// Unsupported.
+    /// </summary>
+    [EnumMember(Value = "XX")]
+    Unsupported,
 }

--- a/GoogleApi/Entities/Translate/Languages/Response/SupportedLanguage.cs
+++ b/GoogleApi/Entities/Translate/Languages/Response/SupportedLanguage.cs
@@ -1,4 +1,5 @@
 using GoogleApi.Entities.Translate.Common.Enums;
+using GoogleApi.Entities.Translate.Common.Enums.Converters;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 
@@ -20,6 +21,6 @@ public class SupportedLanguage
     /// including language + region identifiers are returned(e.g. 'zh-TW' and 'zh-CH')
     /// </summary>
     [JsonProperty("language")]
-    [JsonConverter(typeof(StringEnumConverter))]
+    [JsonConverter(typeof(LanguageEnumConverter))]
     public virtual Language? Language { get; set; }
 }


### PR DESCRIPTION
The current StringEnumConverter throws an exception whenever google adds a new language (we ran into this with #302 when they added 'lus' and then again almost immediately when they added 'jv' as an alternative language code for Javanese). This pull request creates a custom enum converter for parsing the incoming list and assigning unknown codes to a new Language.Unsupported value. 

This shouldn't be an issue in other places since the only place this was used was during the creation of the Response specifically for SupportedLanguages calls.

I'm honestly not sure how to automatically reconcile this long term, but the frequency that google has been adding languages and breaking this call is distressing. Additionally with alternative language codes like we are seeing for Javanese (they support jv and jw) the 'one enum per language' seem unsustainable. Maybe changing from an Enum to a constant string setup for the languages list?