### PR TITLE
Added the Future_Opening status to the BusinessStatus enum.

### DIFF
--- a/GoogleApi/Entities/Common/Enums/BusinessStatus.cs
+++ b/GoogleApi/Entities/Common/Enums/BusinessStatus.cs
@@ -18,5 +18,11 @@ public enum BusinessStatus
     /// <summary>
     /// Closed Permanently
     /// </summary>
-    Closed_Permanently = 2
+    Closed_Permanently = 2,
+
+    //https://github.com/vivet/GoogleApi/issues/305
+    /// <summary>
+    /// Future Opening. 
+    /// </summary>
+    Future_Opening = 3
 }


### PR DESCRIPTION
I didn't save the new Test for this, but a live call to the API was successfully able to parse the response for this call without exception. I figure we can add it and update when google responds to the issue or updates the documentation: https://issuetracker.google.com/issues/249164721