### PR TITLE
Added editorial summary field in search detail response

### DIFF
--- a/GoogleApi/Entities/Places/Common/EditorialSummary.cs
+++ b/GoogleApi/Entities/Places/Common/EditorialSummary.cs
@@ -1,0 +1,23 @@
+using System.Text.Json.Serialization;
+
+namespace GoogleApi.Entities.Places.Common;
+
+#nullable enable
+/// <summary>
+/// Contains a summary of the place. A summary is comprised of a textual overview, and also includes the language code for these if applicable. Summary text must be presented as-is and can not be modified or altered.
+/// </summary>
+public class EditorialSummary
+{
+    /// <summary>
+    /// The language of the previous fields. May not always be present.
+    /// </summary>
+    [JsonPropertyName("language")]
+    public virtual string? Language { get; set; }
+
+    /// <summary>
+    /// 
+    /// </summary>
+    [JsonPropertyName("overview")]
+    public virtual string? Overview { get; set; }
+}
+#nullable restore

--- a/GoogleApi/Entities/Places/Details/Request/Enums/FieldTypes.cs
+++ b/GoogleApi/Entities/Places/Details/Request/Enums/FieldTypes.cs
@@ -99,29 +99,34 @@ public enum FieldTypes
     Website = 1 << 18,
 
     /// <summary>
+    /// Editorial Summary (billing: atmosphere)
+    /// </summary>
+    Editorial_Summary = 1 << 19,
+    
+    /// <summary>
     /// Price Level (billing: atmosphere)
     /// </summary>
-    Price_Level = 1 << 19,
+    Price_Level = 1 << 20,
 
     /// <summary>
     /// Rating (billing: atmosphere).
     /// </summary>
-    Rating = 1 << 20,
+    Rating = 1 << 21,
 
     /// <summary>
     /// Review (billing: atmosphere).
     /// </summary>
-    Review = 1 << 21,
+    Review = 1 << 22,
 
     /// <summary>
     /// User Ratings Total (billing: atmosphere).
     /// </summary>
-    User_Ratings_Total = 1 << 22,
+    User_Ratings_Total = 1 << 23,
 
     /// <summary>
     /// Business Status.
     /// </summary>
-    Business_Status = 1 << 23,
+    Business_Status = 1 << 24,
 
     /// <summary>
     /// Basic (all).
@@ -136,5 +141,5 @@ public enum FieldTypes
     /// <summary>
     /// Atmosphere (all).
     /// </summary>
-    Atmosphere = Price_Level | Rating | User_Ratings_Total | Review
+    Atmosphere = Editorial_Summary | Price_Level | Rating | User_Ratings_Total | Review
 }

--- a/GoogleApi/Entities/Places/Details/Response/DetailsResult.cs
+++ b/GoogleApi/Entities/Places/Details/Response/DetailsResult.cs
@@ -66,6 +66,14 @@ public class DetailsResult
     /// name contains the human-readable name for the returned result. For establishment results, this is usually the canonicalized business name.
     /// </summary>
     public virtual string Name { get; set; }
+    
+    /// <summary>
+    /// Contains a summary of the place. A summary is comprised of a textual overview, and also includes the language code for these if applicable. Summary text must be presented as-is and can not be modified or altered.
+    ///
+    /// See PlaceEditorialSummary for more information.
+    /// </summary>
+    [JsonPropertyName("editorial_summary")]
+    public virtual EditorialSummary EditorialSummary { get; set; }
 
     /// <summary>
     /// opening_hours may contain information about the place opening hours.


### PR DESCRIPTION
The place details did not include the field for `editorial_summary` ([docs link](https://developers.google.com/maps/documentation/places/web-service/details#Place-editorial_summary))

Here's the example of it included in the request and parsed out successfully in the response.
<img width="1455" alt="Google Places editorial summary field" src="https://user-images.githubusercontent.com/1369360/205095796-b15c51e2-7743-4aff-b276-afd3fd521f11.png">
