### PR TITLE
Netstandard 2.0 for main package

### DIFF
--- a/GoogleApi/GoogleApi.csproj
+++ b/GoogleApi/GoogleApi.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<PropertyGroup>
-		<TargetFrameworks>net462;net48;netstandard2.0;netstandard2.1;netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
+		<TargetFrameworks>netstandard2.0</TargetFrameworks>
 		<ApplicationIcon>.\..\icon.ico</ApplicationIcon>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 		<WarningsAsErrors />
@@ -48,7 +48,7 @@
 		<PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
 		<PackageReference Include="System.Text.Json" Version="7.0.0" />
 	</ItemGroup>
-  
+
   <ItemGroup>
 		<None Remove="GoogleApi.csproj.DotSettings" />
 		<None Include="icon.jpg" Pack="true" PackagePath="icon.jpg" />


### PR DESCRIPTION
Since your main package only have a few references that require only `netstandard`;   
I would only target those two "minimum".  This will reduce your package size (from 1.4Mb down to 222kb) and remain compatible with all versions supported **TFM**.   

This does **not drop** support for any **TFM**, but reduces de confusion of which dll it would select at compile/run time.

The test projects would continue to target : `net462`, `net48`, `netcoreapp3.1`, `net6`, `net7`; to ensure proper execution against those **TFM**.

![image](https://user-images.githubusercontent.com/1752811/207889240-195ac450-de40-47df-9a3a-b66feb770c4e.png)

REF: [.NET Standard](https://learn.microsoft.com/en-us/dotnet/standard/net-standard?tabs=net-standard-2-1)