### PR TITLE
SecondaryOpeningHours is an array

### DIFF
--- a/GoogleApi/Entities/Places/Common/PlaceResult.cs
+++ b/GoogleApi/Entities/Places/Common/PlaceResult.cs
@@ -1,8 +1,8 @@
-﻿using System.Collections.Generic;
-using System.Text.Json.Serialization;
-using GoogleApi.Entities.Common;
+﻿using GoogleApi.Entities.Common;
 using GoogleApi.Entities.Common.Enums;
 using GoogleApi.Entities.Places.Common.Enums;
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
 
 namespace GoogleApi.Entities.Places.Common;
 
@@ -169,7 +169,7 @@ public class PlaceResult
     /// the Places Service will bias the results to prefer reviews written in that language.
     /// </summary>
     [JsonPropertyName("reviews")]
-    public virtual IEnumerable<Review> Review { get; set; }
+    public virtual IEnumerable<Review> Reviews { get; set; }
 
     /// <summary>
     /// Contains an array of entries for the next seven days including information about secondary hours of a business.
@@ -180,7 +180,7 @@ public class PlaceResult
     /// See PlaceOpeningHours for more information.
     /// </summary>
     [JsonPropertyName("secondary_opening_hours")]
-    public virtual OpeningHours SecondaryOpeningHours { get; set; }
+    public virtual IEnumerable<OpeningHours> SecondaryOpeningHours { get; set; }
 
     /// <summary>
     /// Specifies if the place serves beer.


### PR DESCRIPTION
Two issues:
1. Reviews is a collection of objects so the property should be plural "Reviews" not "Review".
2. Getting a deserialisation crash when attempting to deserilaise the response on calling the google place api (https://maps.googleapis.com/maps/api/place/details/json?key={your-key}&place_id={google-place-id}), as the "secondary_opening_hours is an array of OpeningHours not a singular openinghour.

The usings have only been re-ordered due to my CodeMaid extension that alphabetically re-ordered the usings on save. Feel free to reject the using order changes.

Note: In our project we use Refit for REST communication, and I was using Newtonsoft Serialization that did not work any more with your project.
You could consider having both System.Text [JsonPropertyName] and Newtonsoft [JsonProperty] attributes such that the response deserialisation would work regardless of the clients choice of serializer. Just an idea, but I have switched to System.Text and tested this change as working against the GooglePlace Api.