### PR TITLE
Fix CLOSED_TEMPORARELY typo

### DIFF
--- a/GoogleApi/Entities/Common/Enums/BusinessStatus.cs
+++ b/GoogleApi/Entities/Common/Enums/BusinessStatus.cs
@@ -16,7 +16,7 @@ public enum BusinessStatus
     /// <summary>
     /// Closed Temporarily.
     /// </summary>
-    [EnumMember(Value = "CLOSED_TEMPORARELY")]
+    [EnumMember(Value = "CLOSED_TEMPORARILY")]
     Closed_Temporarily,
 
     /// <summary>


### PR DESCRIPTION
Causing deserialization failure as the business status:
System.Text.Json.JsonException: The JSON value 'CLOSED_TEMPORARILY' could not be converted to GoogleApi.Entities.Common.Enums.BusinessStatus.

string returned by google is:
"business_status" : "CLOSED_TEMPORARILY",
