### PR TITLE
Mode parameter lower-case in Distance Matrix

### DIFF
--- a/.tests/GoogleApi.Test/Maps/DistanceMatrix/DistanceMatrixTests.cs
+++ b/.tests/GoogleApi.Test/Maps/DistanceMatrix/DistanceMatrixTests.cs
@@ -242,4 +242,42 @@ public class DistanceMatrixTests : BaseTest
         Assert.IsNotNull(response);
         Assert.AreEqual(Status.Ok, response.Status);
     }
+
+    [Test]
+    public async Task DistanceMatrixWhenTravelModeWalking()
+    {
+        var origin = new Address("285 Bedford Ave, Brooklyn, NY, USA");
+        var destination = new Address("185 Broadway Ave, Manhattan, NY, USA");
+        var drivingRequest = new DistanceMatrixRequest
+        {
+            Key = this.Settings.ApiKey,
+            Origins = new[]
+            {
+                new LocationEx(origin)
+            },
+            Destinations = new[]
+            {
+                new LocationEx(destination)
+            },
+            TravelMode = TravelMode.DRIVING,
+        };
+        var drivingResponse = await GoogleMaps.DistanceMatrix.QueryAsync(drivingRequest);
+
+        var walkingRequest = new DistanceMatrixRequest
+        {
+            Key = this.Settings.ApiKey,
+            Origins = new[]
+            {
+                new LocationEx(origin)
+            },
+            Destinations = new[]
+            {
+                new LocationEx(destination)
+            },
+            TravelMode = TravelMode.WALKING,
+        };
+        var walkingResponse = await GoogleMaps.DistanceMatrix.QueryAsync(walkingRequest);
+
+        Assert.AreNotEqual(walkingResponse.RawJson, drivingResponse.RawJson, "Walking travel mode response cannot be identical to Driving mode");
+    }
 }

--- a/GoogleApi/Entities/Maps/DistanceMatrix/Request/DistanceMatrixRequest.cs
+++ b/GoogleApi/Entities/Maps/DistanceMatrix/Request/DistanceMatrixRequest.cs
@@ -147,7 +147,7 @@ public class DistanceMatrixRequest : BaseMapsChannelRequest, IRequestQueryString
             parameters.Add("avoid", this.Avoid.ToEnumString('|'));
         }
 
-        parameters.Add("mode", this.TravelMode.ToString());
+        parameters.Add("mode", this.TravelMode.ToString().ToLower());
 
         switch (this.TravelMode)
         {


### PR DESCRIPTION
When it sends upper-case `WALKING` value for `mode` query parameter this value is ignored and results for default `DRIVING` mode are returned.
Changing it to lower-case `walking` value fixes the issue.

Assume bug was introduced in fix for #386 issue.