### PR TITLE
Bugfix/secondary opening hours

### DIFF
--- a/GoogleApi/Entities/Places/Common/Enums/OpeningHoursType.cs
+++ b/GoogleApi/Entities/Places/Common/Enums/OpeningHoursType.cs
@@ -10,10 +10,34 @@ namespace GoogleApi.Entities.Places.Common.Enums;
 public enum OpeningHoursType
 {
     /// <summary>
-    /// Default value when secondary hour type is not specified.
+    /// The access hours for storage places.
     /// </summary>
-    [EnumMember(Value = "SECONDARY_HOURS_TYPE_UNSPECIFIED")]
-    Secondary_Hours_Type_Unspecified,
+    [EnumMember(Value = "ACCESS")]
+    Access,
+
+    /// <summary>
+    /// Breakfast.
+    /// </summary>
+    [EnumMember(Value = "BREAKFAST")]
+    Breakfast,
+
+    /// <summary>
+    /// Brunch.
+    /// </summary>
+    [EnumMember(Value = "BRUNCH")]
+    Brunch,
+
+    /// <summary>
+    /// Delivery.
+    /// </summary>
+    [EnumMember(Value = "DELIVERY")]
+    Delivery,
+
+    /// <summary>
+    /// Dinner.
+    /// </summary>
+    [EnumMember(Value = "DINNER")]
+    Dinner,
 
     /// <summary>
     /// Drive Through.
@@ -28,28 +52,10 @@ public enum OpeningHoursType
     Happy_Hour,
 
     /// <summary>
-    /// Delivery.
-    /// </summary>
-    [EnumMember(Value = "DELIVERY")]
-    Delivery,
-
-    /// <summary>
-    /// Takeout.
-    /// </summary>
-    [EnumMember(Value = "TAKEOUT")]
-    Takeout,
-
-    /// <summary>
     /// Kitchen.
     /// </summary>
     [EnumMember(Value = "KITCHEN")]
     Kitchen,
-
-    /// <summary>
-    /// Breakfast.
-    /// </summary>
-    [EnumMember(Value = "BREAKFAST")]
-    Breakfast,
 
     /// <summary>
     /// Lunch.
@@ -58,16 +64,10 @@ public enum OpeningHoursType
     Lunch,
 
     /// <summary>
-    /// Dinner.
+    /// Online service hours.
     /// </summary>
-    [EnumMember(Value = "DINNER")]
-    Dinner,
-
-    /// <summary>
-    /// Brunch.
-    /// </summary>
-    [EnumMember(Value = "BRUNCH")]
-    Brunch,
+    [EnumMember(Value = "ONLINE_SERVICE_HOURS")]
+    Online_Service_Hours,
 
     /// <summary>
     /// Pickup.
@@ -76,10 +76,16 @@ public enum OpeningHoursType
     Pickup,
 
     /// <summary>
-    /// The access hours for storage places.
+    /// Reception.
     /// </summary>
-    [EnumMember(Value = "ACCESS")]
-    Access,
+    [EnumMember(Value = "RECEPTION")]
+    Reception,
+
+    /// <summary>
+    /// Default value when secondary hour type is not specified.
+    /// </summary>
+    [EnumMember(Value = "SECONDARY_HOURS_TYPE_UNSPECIFIED")]
+    Secondary_Hours_Type_Unspecified,
 
     /// <summary>
     /// Senior Hours.
@@ -88,14 +94,8 @@ public enum OpeningHoursType
     Senior_Hours,
 
     /// <summary>
-    /// Online service hours.
+    /// Takeout.
     /// </summary>
-    [EnumMember(Value = "ONLINE_SERVICE_HOURS")]
-    Online_Service_Hours,
-
-    /// <summary>
-    /// Reception.
-    /// </summary>
-    [EnumMember(Value = "RECEPTION")]
-    Reception,
+    [EnumMember(Value = "TAKEOUT")]
+    Takeout,
 }

--- a/GoogleApi/Entities/Places/Common/Enums/OpeningHoursType.cs
+++ b/GoogleApi/Entities/Places/Common/Enums/OpeningHoursType.cs
@@ -8,10 +8,10 @@ namespace GoogleApi.Entities.Places.Common.Enums;
 /// Set for secondary_opening_hours only
 /// </summary>
 public enum OpeningHoursType
-{   
+{
     /// <summary>
     /// Default value when secondary hour type is not specified.
-    /// </summary>    
+    /// </summary>
     [EnumMember(Value = "SECONDARY_HOURS_TYPE_UNSPECIFIED")]
     Secondary_Hours_Type_Unspecified,
 
@@ -91,5 +91,11 @@ public enum OpeningHoursType
     /// Online service hours.
     /// </summary>
     [EnumMember(Value = "ONLINE_SERVICE_HOURS")]
-    Online_Service_Hours
+    Online_Service_Hours,
+
+    /// <summary>
+    /// Reception.
+    /// </summary>
+    [EnumMember(Value = "RECEPTION")]
+    Reception,
 }

--- a/GoogleApi/Entities/Places/Common/Enums/OpeningHoursType.cs
+++ b/GoogleApi/Entities/Places/Common/Enums/OpeningHoursType.cs
@@ -7,6 +7,10 @@ namespace GoogleApi.Entities.Places.Common.Enums;
 /// For example, DRIVE_THROUGH, HAPPY_HOUR, DELIVERY, TAKEOUT, KITCHEN, BREAKFAST, LUNCH, DINNER, BRUNCH, PICKUP, SENIOR_HOURS.
 /// Set for secondary_opening_hours only
 /// </summary>
+/// <remarks>
+/// Enum Documentation
+/// https://developers.google.com/maps/documentation/places/android-sdk/reference/com/google/android/libraries/places/api/model/OpeningHours.HoursType
+/// </remarks>
 public enum OpeningHoursType
 {
     /// <summary>
@@ -97,5 +101,5 @@ public enum OpeningHoursType
     /// Takeout.
     /// </summary>
     [EnumMember(Value = "TAKEOUT")]
-    Takeout,
+    Takeout
 }


### PR DESCRIPTION
Google has an undocumented OpeningHoursType - RECEPTION
We are getting Json Serialisation failures - example GooglePlaceId - ChIJAwsWnpoPkWsRxmVS2VIxJS8

```
The JSON value 'RECEPTION' could not be converted to GoogleApi.Entities.Places.Common.Enums.OpeningHoursType. Path: $.result.secondary_opening_hours[0].type | LineNumber: 281 | BytePositionInLine: 32.
```

Added RECEPTION as an enum and re-ordered the enum alphabetically for easier comparison to documentation