### PR TITLE
Add missing serializer method

### DIFF
--- a/GoogleApi/Entities/Common/Converters/StringSecondsTimeSpanJsonConverter.cs
+++ b/GoogleApi/Entities/Common/Converters/StringSecondsTimeSpanJsonConverter.cs
@@ -34,6 +34,9 @@ public class StringSecondsTimeSpanJsonConverter : JsonConverter<TimeSpan>
     /// <inheritdoc />
     public override void Write(Utf8JsonWriter writer, TimeSpan value, JsonSerializerOptions options)
     {
-        throw new NotImplementedException();
+        if (writer == null)
+            throw new ArgumentNullException(nameof(writer));
+
+        writer.WriteStringValue($"{value.TotalSeconds}s");
     }
 }


### PR DESCRIPTION
The Write method in StringSecondsTimeSpanJsonConverter is missing, causing exceptions when serializing data back to JSON. Implement the missing method.