### PR TITLE
Fix typo

### DIFF
--- a/GoogleApi/Entities/Common/Enums/PlaceLocationType.cs
+++ b/GoogleApi/Entities/Common/Enums/PlaceLocationType.cs
@@ -547,7 +547,7 @@ public enum PlaceLocationType
     /// Tourist Attracton.
     /// </summary>
     [EnumMember(Value = "tourist_attraction")]
-    Tourist_Attracton,
+    Tourist_Attraction,
 
     /// <summary>
     /// Train Station.


### PR DESCRIPTION
Fixes a typo in the PlaceLocationType enum 