### PR TITLE
Bug: IncludedType in PlacesNewTextSearchRequest has default value

### DIFF
--- a/GoogleApi/Entities/PlacesNew/Search/Text/Request/PlacesNewTextSearchRequest.cs
+++ b/GoogleApi/Entities/PlacesNew/Search/Text/Request/PlacesNewTextSearchRequest.cs
@@ -38,7 +38,7 @@ public class PlacesNewTextSearchRequest : BasePlacesNewRequest, IRequestJsonX
     /// Restricts the results to places matching the specified type defined by Table A. Only one type may be specified.
     /// https://developers.google.com/maps/documentation/places/web-service/place-types#table-a
     /// </summary>
-    public virtual PlaceLocationTypeA IncludedType { get; set; }
+    public virtual PlaceLocationTypeA? IncludedType { get; set; }
 
     /// <summary>
     /// Optional.


### PR DESCRIPTION
This PR fixes an issue where `IncludedType` in `PlacesNewTextSearchRequest` accidentally has the default value (which is `CarDealer`). The request was serialized to:
```json
{
  "textQuery" : "ChainRestaurant New York",
  "includedType" : "car_dealer", <--
  "includePureServiceAreaBusinesses" : false,
  "languageCode" : "en",
  "openNow" : false,
  "pageSize" : 20,
  "priceLevels" : [ ],
  "strictTypeFiltering" : false
}
```

The problem is solved by making this property nullable.