### PR TITLE
Bug: PrimaryType default null, Places default empty list

### DIFF
--- a/GoogleApi/Entities/PlacesNew/Common/Place.cs
+++ b/GoogleApi/Entities/PlacesNew/Common/Place.cs
@@ -38,7 +38,7 @@ public class Place
     /// For example, "restaurant", "cafe", "airport", etc. A place can only have a single primary type.
     /// For the complete list of possible values, see Table A and Table B at https://developers.google.com/maps/documentation/places/web-service/place-types
     /// </summary>
-    public virtual PlaceLocationTypeAb PrimaryType { get; set; }
+    public virtual PlaceLocationTypeAb? PrimaryType { get; set; }
 
     /// <summary>
     /// The display name of the primary type, localized to the request language if applicable.

--- a/GoogleApi/Entities/PlacesNew/Search/Text/Response/PlacesNewTextSearchResponse.cs
+++ b/GoogleApi/Entities/PlacesNew/Search/Text/Response/PlacesNewTextSearchResponse.cs
@@ -10,7 +10,7 @@ namespace GoogleApi.Entities.PlacesNew.Search.Text.Response;
 public class PlacesNewTextSearchResponse : BaseResponseX
 {
     /// <summary>
-    /// A list of places that meet the user's text search criteria..
+    /// A list of places that meet the user's text search criteria.
     /// </summary>
     public virtual IEnumerable<Place> Places { get; set; }
 

--- a/GoogleApi/Entities/PlacesNew/Search/Text/Response/PlacesNewTextSearchResponse.cs
+++ b/GoogleApi/Entities/PlacesNew/Search/Text/Response/PlacesNewTextSearchResponse.cs
@@ -12,7 +12,7 @@ public class PlacesNewTextSearchResponse : BaseResponseX
     /// <summary>
     /// A list of places that meet the user's text search criteria.
     /// </summary>
-    public virtual IEnumerable<Place> Places { get; set; }
+    public virtual IEnumerable<Place> Places { get; set; } = new List<Place>();
 
     /// <summary>
     /// A list of routing summaries where each entry associates to the corresponding place in the same index in the places field.


### PR DESCRIPTION
Fixed some issues for the Places (new) API:
- `PrimaryType` default null in the response class (instead of the default enum value `CarDealer`). Related to #408
- When the response of the text search API is empty, the `Places` property should be an empty list instead of null (in my opinion, let me know if you disagree).