### PR TITLE
allow adding custom http headers to the produced requests

### DIFF
--- a/GoogleApi/HttpEngine.cs
+++ b/GoogleApi/HttpEngine.cs
@@ -99,7 +99,7 @@ public class HttpEngine<TRequest, TResponse> : HttpEngine
 
         try
         {
-            using var httpResponseMessage = await this.ProcessRequestAsync(request, cancellationToken)
+            using var httpResponseMessage = await this.ProcessRequestAsync(request, httpEngineOptions, cancellationToken)
                 .ConfigureAwait(false);
 
             var response = await this.ProcessResponseAsync(httpResponseMessage)
@@ -146,7 +146,7 @@ public class HttpEngine<TRequest, TResponse> : HttpEngine
         }
     }
 
-    private async Task<HttpResponseMessage> ProcessRequestAsync(TRequest request, CancellationToken cancellationToken = default)
+    private async Task<HttpResponseMessage> ProcessRequestAsync(TRequest request, HttpEngineOptions httpEngineOptions, CancellationToken cancellationToken = default)
     {
         if (request == null)
             throw new ArgumentNullException(nameof(request));
@@ -159,6 +159,12 @@ public class HttpEngine<TRequest, TResponse> : HttpEngine
             : HttpMethod.Post;
 
         using var httpRequestMessage = new HttpRequestMessage(method, uri);
+
+        if (httpEngineOptions.AdditionalHeaders != null) {
+            foreach (var header in httpEngineOptions.AdditionalHeaders ) { 
+                httpRequestMessage.Headers.Add(header.Key, header.Value); 
+            }
+        }
 
         if (request is IRequestX jsonX)
         {

--- a/GoogleApi/HttpEngineOptions.cs
+++ b/GoogleApi/HttpEngineOptions.cs
@@ -1,12 +1,19 @@
-﻿namespace GoogleApi;
+﻿using System.Collections.Generic;
+
+namespace GoogleApi;
 
 /// <summary>
 /// Http Engine Options.
 /// </summary>
-public class HttpEngineOptions
-{
-    /// <summary>
-    /// Throw On Bad Request.
-    /// </summary>
-    public virtual bool ThrowOnInvalidRequest { get; set; } = true;
+public class HttpEngineOptions {
+	/// <summary>
+	/// Throw On Bad Request.
+	/// </summary>
+	public virtual bool ThrowOnInvalidRequest { get; set; } = true;
+
+	/// <summary>
+	/// Allows you to add custom HTTP headers to the requests.
+	/// </summary>
+	/// <example>new HttpEngineOptions { AdditionalHeaders = new() { { "Referer", "https://www.yoursite.com" } } }</example>
+	public Dictionary<string, string> AdditionalHeaders { get; set; }
 }


### PR DESCRIPTION
Some APIs can be restricted to some specific domains (for example the maps) and there was no way to include the referer in the requests sent by the library. Now you can do that. If your api key is restricted to www.yourdomain.com, then you can now set

`var options = new HttpEngineOptions { AdditionalHeaders = new() { { "Referer", "https://www.yourdomain.com" } } };`

and then pass those options to api.QueryAsync()