### PR TITLE
Add the referer or custom HTTP headers

### DIFF
--- a/GoogleApi/HttpEngine.cs
+++ b/GoogleApi/HttpEngine.cs
@@ -99,7 +99,7 @@ public class HttpEngine<TRequest, TResponse> : HttpEngine
 
         try
         {
-            using var httpResponseMessage = await this.ProcessRequestAsync(request, cancellationToken)
+            using var httpResponseMessage = await this.ProcessRequestAsync(request, httpEngineOptions, cancellationToken)
                 .ConfigureAwait(false);
 
             var response = await this.ProcessResponseAsync(httpResponseMessage)
@@ -146,7 +146,7 @@ public class HttpEngine<TRequest, TResponse> : HttpEngine
         }
     }
 
-    private async Task<HttpResponseMessage> ProcessRequestAsync(TRequest request, CancellationToken cancellationToken = default)
+    private async Task<HttpResponseMessage> ProcessRequestAsync(TRequest request, HttpEngineOptions httpEngineOptions, CancellationToken cancellationToken = default)
     {
         if (request == null)
             throw new ArgumentNullException(nameof(request));
@@ -159,6 +159,12 @@ public class HttpEngine<TRequest, TResponse> : HttpEngine
             : HttpMethod.Post;
 
         using var httpRequestMessage = new HttpRequestMessage(method, uri);
+
+        if (httpEngineOptions.AdditionalHeaders != null) {
+            foreach (var header in httpEngineOptions.AdditionalHeaders ) { 
+                httpRequestMessage.Headers.Add(header.Key, header.Value); 
+            }
+        }
 
         if (request is IRequestX jsonX)
         {

--- a/GoogleApi/HttpEngineOptions.cs
+++ b/GoogleApi/HttpEngineOptions.cs
@@ -1,12 +1,19 @@
-﻿namespace GoogleApi;
+﻿using System.Collections.Generic;
+
+namespace GoogleApi;
 
 /// <summary>
 /// Http Engine Options.
 /// </summary>
-public class HttpEngineOptions
-{
-    /// <summary>
-    /// Throw On Bad Request.
-    /// </summary>
-    public virtual bool ThrowOnInvalidRequest { get; set; } = true;
+public class HttpEngineOptions {
+	/// <summary>
+	/// Throw On Bad Request.
+	/// </summary>
+	public virtual bool ThrowOnInvalidRequest { get; set; } = true;
+
+	/// <summary>
+	/// Allows you to add custom HTTP headers to the requests.
+	/// </summary>
+	/// <example>new HttpEngineOptions { AdditionalHeaders = new() { { "Referer", "https://www.yoursite.com" } } }</example>
+	public Dictionary<string, string> AdditionalHeaders { get; set; }
 }

--- a/GoogleApi/HttpEngineOptions.cs
+++ b/GoogleApi/HttpEngineOptions.cs
@@ -16,4 +16,20 @@ public class HttpEngineOptions {
 	/// </summary>
 	/// <example>new HttpEngineOptions { AdditionalHeaders = new() { { "Referer", "https://www.yoursite.com" } } }</example>
 	public Dictionary<string, string> AdditionalHeaders { get; set; }
+
+	/// <summary>
+	/// Specify the referer to send in the request in case your API key is restricted to specific domains.
+	/// You need to specify one of the allowed domains, if you receive "PermissionDenied: Requests from referer &lt;empty> are blocked." errors.
+	/// https://cloud.google.com/api-keys/docs/add-restrictions-api-keys#add-client-restrictions
+	/// </summary>
+	public string Referer
+	{
+		get {
+			return AdditionalHeaders != null && AdditionalHeaders.TryGetValue("Referer", out var referer) ? referer : null;
+		}
+		set {
+			AdditionalHeaders ??= [];
+			AdditionalHeaders["Referer"] = value;
+		}
+	}
 }


### PR DESCRIPTION
Specify the referer in case your API key is restricted to specific domain(s) and you receive the "PermissionDenied: Requests from referer <empty> are blocked." error

https://cloud.google.com/api-keys/docs/add-restrictions-api-keys#add-client-restrictions