### PR TITLE
Fix Typo in AuthorAttribution.DisplayName

### DIFF
--- a/GoogleApi/Entities/PlacesNew/Common/AuthorAttribution.cs
+++ b/GoogleApi/Entities/PlacesNew/Common/AuthorAttribution.cs
@@ -8,7 +8,7 @@ public class AuthorAttribution
     /// <summary>
     /// Name of the author of the Photo or Review.
     /// </summary>
-    public virtual string DdisplayName { get; set; }
+    public virtual string DisplayName { get; set; }
 
     /// <summary>
     /// URI of the author of the Photo or Review.


### PR DESCRIPTION
I was confused, because the author name was always empty. 
Looking at https://developers.google.com/maps/documentation/places/web-service/reference/rest/v1/places#AuthorAttribution i assume "DdisplayName" was just a typo?